### PR TITLE
CQ-4321083:Core and Frontend Module not getting transformed in Repo M…

### DIFF
--- a/packages/repository-modernizer/src/create-base-project-structure.js
+++ b/packages/repository-modernizer/src/create-base-project-structure.js
@@ -447,16 +447,17 @@ function copyOtherModules(project, conversionStep) {
         if (
             !fs.existsSync(destinationFolderPath) &&
             !ignoredPaths.includes(srcFolderPath) &&
+            !srcFolderPath.includes("dispatcher") &&
             pomManipulationUtil.verifyArtifactPackagingType(
                 pomFile,
-                constants.CONTENT_PACKAGE
+                constants.CONTENT_PACKAGING_TYPES
             )
         ) {
             copyModuleFromSource(
                 srcFolderPath,
-                destination,
+                destinationFolderPath,
                 project.appId,
-                constants.CONTENT_PACKAGE,
+                constants.CONTENT_PACKAGING_TYPES,
                 conversionStep
             );
         }

--- a/packages/repository-modernizer/src/create-base-project-structure.js
+++ b/packages/repository-modernizer/src/create-base-project-structure.js
@@ -457,7 +457,7 @@ function copyOtherModules(project, conversionStep) {
                 srcFolderPath,
                 destinationFolderPath,
                 project.appId,
-                constants.CONTENT_PACKAGING_TYPES,
+                constants.CONTENT_PACKAGE,
                 conversionStep
             );
         }

--- a/packages/repository-modernizer/src/util/constants.js
+++ b/packages/repository-modernizer/src/util/constants.js
@@ -65,9 +65,9 @@ module.exports = {
 
     NON_ADOBE_DEPENDENCIES: "nonadobedependencies",
 
-    BUNDLE: "bundle",
+    BUNDLE: ["bundle"],
 
-    CONTENT_PACKAGE: "content-package",
+    CONTENT_PACKAGING_TYPES: ["content-package", "pom"],
 
     // POM tags and entries
 

--- a/packages/repository-modernizer/src/util/constants.js
+++ b/packages/repository-modernizer/src/util/constants.js
@@ -65,7 +65,9 @@ module.exports = {
 
     NON_ADOBE_DEPENDENCIES: "nonadobedependencies",
 
-    BUNDLE: ["bundle"],
+    BUNDLE: "bundle",
+
+    CONTENT_PACKAGE: "content-package",
 
     CONTENT_PACKAGING_TYPES: ["content-package", "pom"],
 

--- a/packages/repository-modernizer/src/util/pom-manipulation-util.js
+++ b/packages/repository-modernizer/src/util/pom-manipulation-util.js
@@ -69,7 +69,7 @@ var PomManipulationUtil = {
     /**
      *
      * @param String pomFilePath  path of pom file in whose packaging type need to be checked
-     * @param String expectedPackaging  the expected packaging type
+     * @param Array.<String> expectedPackaging  array of string containing packaging type
      *
      * Check the artifact's packaging type
      */
@@ -83,7 +83,7 @@ var PomManipulationUtil = {
                     line.indexOf(constants.PACKAGING_TAG_END)
                 );
                 // return whether the packaging type matches
-                return expectedPackaging === packagingType.trim();
+                return expectedPackaging.includes(packagingType.trim());
             }
         }
         // packaging type not found


### PR DESCRIPTION
…odernizer

CQ-4321083 Core and Frontend Module not getting transformed in Repo Modernizer

## Description

Made expected packaging type as array and added packaging type pom as valid type to copy with exception of ignoring dispatcher folder


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
