### PR TITLE
CQ-4330105 : [Dispatcher Converter] Migration failure for AMS based project due to `rules` files inclusion.

### DIFF
--- a/packages/dispatcher-converter/src/util/FileOperations.js
+++ b/packages/dispatcher-converter/src/util/FileOperations.js
@@ -910,37 +910,29 @@ class FileOperations {
                     let indentation = line.length - trimmedLine.length;
                     // replace the include statement with the rule file's content
                     if (ruleFileContent) {
-                        let ruleFileContentArray = ruleFileContent.split(
-                            os.EOL
-                        );
-                        ruleFileContentArray.forEach(
-                            (ruleFileContentArrayLine) => {
-                                // adjust the line to match the include statement's indentation
-                                returnContent +=
-                                    line.substring(0, indentation) +
-                                    ruleFileContentArrayLine +
-                                    os.EOL;
-                                logger.info(
-                                    "FileOperationsUtility: Replaced include statement " +
-                                        trimmedLine +
-                                        " in  file " +
-                                        filePath
-                                );
-                                let conversion_operation =
-                                    new ConversionOperation(
-                                        commons_constants.ACTION_REPLACED,
-                                        filePath,
-                                        "Replaced include statement '" +
-                                            trimmedLine +
-                                            " with content of file '" +
-                                            ruleFileToReplace +
-                                            "'"
-                                    );
-                                conversionStep.addOperation(
-                                    conversion_operation
-                                );
-                            }
-                        );
+                        ruleFileContent.forEach((ruleFileContentArrayLine) => {
+                            // adjust the line to match the include statement's indentation
+                            returnContent +=
+                                line.substring(0, indentation) +
+                                ruleFileContentArrayLine +
+                                os.EOL;
+                            logger.info(
+                                "FileOperationsUtility: Replaced include statement " +
+                                    trimmedLine +
+                                    " in  file " +
+                                    filePath
+                            );
+                            let conversion_operation = new ConversionOperation(
+                                commons_constants.ACTION_REPLACED,
+                                filePath,
+                                "Replaced include statement '" +
+                                    trimmedLine +
+                                    " with content of file '" +
+                                    ruleFileToReplace +
+                                    "'"
+                            );
+                            conversionStep.addOperation(conversion_operation);
+                        });
                     }
                     logger.info(
                         "FileOperationsUtility: Replaced include statement '%s' in file %s.",

--- a/packages/dispatcher-converter/test/FileOperationsTest.js
+++ b/packages/dispatcher-converter/test/FileOperationsTest.js
@@ -543,7 +543,7 @@ describe("FileOperations", function () {
             testFolder,
             "vhost",
             "test",
-            "content",
+            ["content"],
             "Virtual",
             new ConversionStep()
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

FileOperations.getXmlContentSync already returns the array of content of file splitted by new line.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
